### PR TITLE
1)

### DIFF
--- a/xt_ratelimit.c
+++ b/xt_ratelimit.c
@@ -85,15 +85,14 @@ struct ratelimit_car {
 
 	u32 cbs;			/* committed burst size (bytes) */
 	u32 ebs;			/* extended burst size (bytes) */
-	u32 cir;			/* committed information rate (bits/s) */
+	u32 cir_hz;   /* committed information rate (bits/s) / (HZ * 8) */
 };
 
 struct ratelimit_stat {
-	u64 green_bytes;
-	u64 red_bytes;
-	u32 green_pkt;
-	u32 red_pkt;
-	unsigned long first;		/* first time seen */
+	atomic64_t green_bytes;
+	atomic64_t red_bytes;
+	atomic_t green_pkt;
+	atomic_t red_pkt;
 
 #ifdef RATE_ESTIMATOR
 #define RATEST_SECONDS 4		/* length of rate estimator time slot */
@@ -198,7 +197,7 @@ static int ratelimit_seq_ent_show(struct ratelimit_match *mt,
 		    &ent->matches[i].addr);
 	}
 	seq_printf(s, " cir %u cbs %u ebs %u;",
-	    ent->car.cir, ent->car.cbs, ent->car.ebs);
+	    ent->car.cir_hz * (HZ * BITS_PER_BYTE), ent->car.cbs, ent->car.ebs);
 
 	seq_printf(s, " tc %u te %u last", ent->car.tc, ent->car.te);
 	if (ent->car.last)
@@ -207,14 +206,16 @@ static int ratelimit_seq_ent_show(struct ratelimit_match *mt,
 		seq_printf(s, " never;");
 
 	seq_printf(s, " conf %u/%llu",
-	    ent->stat.green_pkt, ent->stat.green_bytes);
+	    (u32)atomic_read(&ent->stat.green_pkt),
+		 (u64)atomic64_read(&ent->stat.green_bytes));
 
 #ifdef RATE_ESTIMATOR
 	seq_printf(s, " %lu bps", calc_rate_est(&ent->stat));
 #endif
 
 	seq_printf(s, ", rej %u/%llu",
-	    ent->stat.red_pkt, ent->stat.red_bytes);
+	    (u32)atomic_read(&ent->stat.red_pkt),
+		 (u64)atomic64_read(&ent->stat.red_bytes));
 
 	seq_printf(s, "\n");
 
@@ -442,7 +443,7 @@ static int parse_rule(struct xt_ratelimit_htable *ht, char *str, size_t size)
 		val = simple_strtoul(v, NULL, 10);
 		switch (i) {
 			case 0:
-				ent->car.cir = val;
+				ent->car.cir_hz = val / (HZ * BITS_PER_BYTE);
 				/* autoconfigure optimal parameters */
 				val = val / 8 + (val / 8 / 2);
 				/* FALLTHROUGH */
@@ -841,37 +842,40 @@ ratelimit_mt(const struct sk_buff *skb, struct xt_action_param *par)
 	if (ent) {
 		struct ratelimit_car *car = &ent->car;
 		const unsigned int len = skb->len; /* L3 */
-		const unsigned long delta_ms = (now - car->last) * (MSEC_PER_SEC / HZ);
+		const u32 tok = (now - car->last) * car->cir_hz;
 
 		spin_lock(&ent->lock_bh);
 		car->tc += len;
-		if (delta_ms) {
-			const u32 tok = delta_ms * (car->cir / (BITS_PER_BYTE * MSEC_PER_SEC));
-
+		if (tok) {
 			car->tc -= min(tok, car->tc);
-			if (!ent->stat.first)
-				ent->stat.first = now;
 			car->last = now;
 		}
 		if (car->tc > car->cbs) { /* extended burst */
 			car->te += car->tc - car->cbs;
 			if (car->te > car->ebs) {
 				car->te = 0;
+				car->tc -= len;
 				match = true; /* match is drop */
 			}
 		}
+#ifndef RATE_ESTIMATOR
+		spin_unlock(&ent->lock_bh);
+#endif
+
 		if (match) {
-			ent->stat.red_bytes += len;
-			ent->stat.red_pkt++;
-			car->tc -= len;
+			atomic64_add(len, &ent->stat.red_bytes);
+			atomic_inc(&ent->stat.red_pkt);
 		} else {
-			ent->stat.green_bytes += len;
-			ent->stat.green_pkt++;
+			atomic64_add(len, &ent->stat.green_bytes);
+			atomic_inc(&ent->stat.green_pkt);
 #ifdef RATE_ESTIMATOR
 			rate_estimator(&ent->stat, now / RATEST_JIFFIES, len);
 #endif
 		}
+
+#ifdef RATE_ESTIMATOR
 		spin_unlock(&ent->lock_bh);
+#endif
 	} else {
 		if (ht->other == OT_MATCH)
 			match = true; /* match is drop */


### PR DESCRIPTION
const u32 tok = delta_ms * (car->cir / (BITS_PER_BYTE * MSEC_PER_SEC));

Раccчет tok не зависит от переменных, изменяемых внутри критической секции (cs).
Он зависит от delte_ms, которая рассчитывается вне cs и от cir - фактически константа.
Если в рассчет tok подставить формул delta_ms, пыполнить сокращения, то останется
(now - car->last) * (car->cir / (HZ * BITS_PER_BYTE))

Можно выссчитывать вот эту часть заранее, избавившись от лишнего деления (он ведь дорогие,
вроде дороже умножения).

 car->cir_hz = (car->cir / (HZ * BITS_PER_BYTE))

В итоге получим
 const u32 tok = (now - car->last) * car->cir_hz;

Конечно, добавится умножение в выводе статистике, она же должна много реже выводиться.

2)
критическую секцию можно еще упростить, вынести статистику во вне и переведя ее на atomic операции.
Правда в случае включенного RATE_ESTIMATOR укоратить cs вроде не получается, но вот я бы у себя
его выключил. Это ведь тоже только статистика, правильно?

3)
переменная struct ratelimit_stat.first нигде не используется.
просто удалил.