### PR TITLE
Fix builds on iptables version 1.8.9 or newer

### DIFF
--- a/libxt_ratelimit.c
+++ b/libxt_ratelimit.c
@@ -153,7 +153,7 @@ static struct xtables_match ratelimit_mt_reg[] = {
 	},
 };
 
-void _init(void)
+static void __attribute__((constructor)) _init(void)
 {
 	xtables_register_matches(ratelimit_mt_reg, ARRAY_SIZE(ratelimit_mt_reg));
 }


### PR DESCRIPTION
Ever since iptables commit ef108943f69a6e20533d58823740d3f0534ea8ec,
the _init macro has become guarded by XTABLES_INTERNAL, thus breaking
this extension.