### PR TITLE
Fix echo @- returning error

### DIFF
--- a/xt_ratelimit.c
+++ b/xt_ratelimit.c
@@ -580,9 +580,11 @@ static int parse_rule(struct xt_ratelimit_htable *ht, char *str, size_t size)
 		 * should be equal (this is correct, because duplications
 		 * inside of set(s) are impossible) */
 		if (!ent_chk) {
-			if (warn)
+			if (warn) {
 				pr_err("Del op doesn't reference any existing address (cmd: %s)\n", buf);
-			goto unlock_einval;
+				goto unlock_einval;
+			}
+			goto retok;
 		}
 		if (ent_chk->mtcnt != ent->mtcnt) {
 			pr_err("Del op doesn't match other rule set fully (cmd: %s)\n", buf);
@@ -602,6 +604,8 @@ static int parse_rule(struct xt_ratelimit_htable *ht, char *str, size_t size)
 		}
 	} else
 		ratelimit_ent_del(ht, ent_chk);
+
+retok:
 	spin_unlock(&ht->lock);
 
 	if (ent)


### PR DESCRIPTION
@- now suppress only dmesg message. Stderr message is shown. And exit code of echo is not 0. This makes scripting more complicated.

Makes @- suppress stderr message too (and exit with 0 exit code).